### PR TITLE
Fix some trivial issues in docker-compose file

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,1 +1,2 @@
 /volumes
+*.local.yaml

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -59,8 +59,10 @@ services:
       - "8765:8765"
     command: -c /etc/envoy/envoy.yaml --log-level debug 
     volumes:
-      - ./envoy-for-mac.yaml:/etc/envoy/envoy.yaml
+      - ./envoy.yaml:/etc/envoy/envoy.yaml
       - ../proto/exchange/matchengine.pb:/tmp/envoy/matchengine.pb
       - ../proto/rollup/rollup.pb:/tmp/envoy/rollup.pb
     extra_hosts:
+    #work from 20.04 of docker engine, for earlier version, try 172.17.0.1 trick
       - "host.docker.internal:host-gateway"
+

--- a/docker/envoy.yaml
+++ b/docker/envoy.yaml
@@ -74,7 +74,7 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: 0.0.0.0
+                address: host.docker.internal
                 port_value: 50051
 
   - name: grpc_rollup
@@ -93,7 +93,7 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: 0.0.0.0
+                address: host.docker.internal
                 port_value: 50061
 
 
@@ -113,5 +113,5 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: 0.0.0.0
+                address: host.docker.internal
                 port_value: 50053


### PR DESCRIPTION
In docker directory, we have a separated compose file for mac host now. However, the default compose file also specify env a configuration file which should be used for mac (envoy-for-mac.yaml) and this seems somewhat inconsistent. Maybe it should be updated to the original one (envoy.yaml)

Also for docker engine later than 20.04 the "host.docker.internal" hostname has also worked for linux, but "0.0.0.0" seems never work as expected so I also update the envoy.yaml

And I made "local.yaml" file would be omitted by git so user can be easily put their overriding compose files named as xxx.local.yaml.